### PR TITLE
Reorder Assert.AreEqual() parameter values

### DIFF
--- a/Source/NHibernate.Extensions.Tests/BaseIncludeTest.cs
+++ b/Source/NHibernate.Extensions.Tests/BaseIncludeTest.cs
@@ -15,22 +15,22 @@ namespace NHibernate.Extensions.Tests
     {
         protected void ValidateGetEntityResult(EQBPerson petra)
         {
-            Assert.AreEqual(petra.BestFriend.Name, "Ana");
-            Assert.AreEqual(petra.BestFriend.BestFriend.Name, "Simon");
-            Assert.AreEqual(petra.BestFriend.IdentityCard.Code, "1");
-            Assert.AreEqual(petra.BestFriend.BestFriend.BestFriend.Name, "Rok");
-            Assert.AreEqual(petra.BestFriend.BestFriend.BestFriend.BestFriend.Name, "Petra");
-            Assert.AreEqual(petra.BestFriend.BestFriend.BestFriend.BestFriend.BestFriend.Name, "Ana");
-            Assert.AreEqual(petra.CurrentOwnedVehicles.Count, 1);
-            Assert.AreEqual(petra.DrivingLicence.Code, "3");
-            Assert.AreEqual(petra.IdentityCard.Code, "4");
-            Assert.AreEqual(petra.CreatedBy.UserName, "System");
-            Assert.AreEqual(petra.MarriedWith, petra.BestFriend.BestFriend);
-            Assert.AreEqual(petra.OwnedHouses.Count, 1);
-            Assert.AreEqual(petra.PreviouslyOwnedVehicles.Count, 2);
+            Assert.AreEqual("Ana", petra.BestFriend.Name);
+            Assert.AreEqual("Simon", petra.BestFriend.BestFriend.Name);
+            Assert.AreEqual("1", petra.BestFriend.IdentityCard.Code);
+            Assert.AreEqual("Rok", petra.BestFriend.BestFriend.BestFriend.Name);
+            Assert.AreEqual("Petra", petra.BestFriend.BestFriend.BestFriend.BestFriend.Name);
+            Assert.AreEqual("Ana", petra.BestFriend.BestFriend.BestFriend.BestFriend.BestFriend.Name);
+            Assert.AreEqual(1, petra.CurrentOwnedVehicles.Count);
+            Assert.AreEqual("3", petra.DrivingLicence.Code);
+            Assert.AreEqual("4", petra.IdentityCard.Code);
+            Assert.AreEqual("System", petra.CreatedBy.UserName);
+            Assert.AreEqual(petra.BestFriend.BestFriend, petra.MarriedWith);
+            Assert.AreEqual(1, petra.OwnedHouses.Count);
+            Assert.AreEqual(2, petra.PreviouslyOwnedVehicles.Count);
             foreach (var wheel in petra.CurrentOwnedVehicles.First().Wheels)
             {
-                Assert.AreEqual(wheel.Width, 235);
+                Assert.AreEqual(235, wheel.Width);
             }
         }
 

--- a/Source/NHibernate.Extensions.Tests/DeepCloneTests.cs
+++ b/Source/NHibernate.Extensions.Tests/DeepCloneTests.cs
@@ -64,7 +64,7 @@ namespace NHibernate.Extensions.Tests
                     );
 
             }
-            Assert.AreEqual(clone.Id, default(int));
+            Assert.AreEqual(default(int), clone.Id);
             Assert.IsNull(clone.Name);
             Assert.AreEqual(petra.LastName, clone.LastName);
             Assert.AreEqual(petra.IdentityCard, clone.IdentityCard);

--- a/Source/NHibernate.Extensions.Tests/LinqIncludeTests.cs
+++ b/Source/NHibernate.Extensions.Tests/LinqIncludeTests.cs
@@ -303,7 +303,7 @@ namespace NHibernate.Extensions.Tests
 
                 Assert.AreEqual(1, stats.PrepareStatementCount);
             }
-            //Assert.AreEqual(petra.CreatedBy.UserName, "System");
+            //Assert.AreEqual("System", petra.CreatedBy.UserName);
         }
 
         [TestMethod]
@@ -342,7 +342,7 @@ namespace NHibernate.Extensions.Tests
                 Assert.AreEqual(1, stats.PrepareStatementCount);
                 Assert.AreEqual("1 queries (MultiQuery)", stats.Queries[0]);
             }
-            Assert.AreEqual(petra.CreatedBy.UserName, "System");
+            Assert.AreEqual("System", petra.CreatedBy.UserName);
         }
 
         [TestMethod]
@@ -363,7 +363,7 @@ namespace NHibernate.Extensions.Tests
                 Assert.AreEqual("1 queries (MultiQuery)", stats.Queries[0]);
             }
             Assert.IsNotNull(petra);
-            Assert.AreEqual(petra.CreatedBy.UserName, "System");
+            Assert.AreEqual("System", petra.CreatedBy.UserName);
         }
 
         [TestMethod]
@@ -384,7 +384,7 @@ namespace NHibernate.Extensions.Tests
                 Assert.AreEqual("1 queries (MultiQuery)", stats.Queries[0]);
             }
             Assert.IsNotNull(petra);
-            Assert.AreEqual(petra.CreatedBy.UserName, "System");
+            Assert.AreEqual("System", petra.CreatedBy.UserName);
         }
 
         [TestMethod]

--- a/Source/NHibernate.Extensions.Tests/QueryRelationTreeTests.cs
+++ b/Source/NHibernate.Extensions.Tests/QueryRelationTreeTests.cs
@@ -28,13 +28,13 @@ namespace NHibernate.Extensions.Tests
 
             var results = tree.DeepFirstSearch();
             //Output
-            Assert.AreEqual(results[0][0], "BestFriend");
-            Assert.AreEqual(results[0][1], "BestFriend.IdentityCard");
+            Assert.AreEqual("BestFriend", results[0][0]);
+            Assert.AreEqual("BestFriend.IdentityCard", results[0][1]);
 
-            Assert.AreEqual(results[1][0], "BestFriend");
-            Assert.AreEqual(results[1][1], "BestFriend.BestFriend");
-            Assert.AreEqual(results[1][2], "BestFriend.BestFriend.BestFriend");
-            Assert.AreEqual(results[1][3], "BestFriend.BestFriend.BestFriend.BestFriend");
+            Assert.AreEqual("BestFriend", results[1][0]);
+            Assert.AreEqual("BestFriend.BestFriend", results[1][1]);
+            Assert.AreEqual("BestFriend.BestFriend.BestFriend", results[1][2]);
+            Assert.AreEqual("BestFriend.BestFriend.BestFriend.BestFriend", results[1][3]);
         }
 
         [TestMethod]
@@ -52,16 +52,16 @@ namespace NHibernate.Extensions.Tests
 
             var results = tree.DeepFirstSearch();
             //Output
-            Assert.AreEqual(results[0][0], "BestFriend");
-            Assert.AreEqual(results[0][1], "BestFriend.IdentityCard");
+            Assert.AreEqual("BestFriend", results[0][0]);
+            Assert.AreEqual("BestFriend.IdentityCard", results[0][1]);
 
-            Assert.AreEqual(results[1][0], "BestFriend");
-            Assert.AreEqual(results[1][1], "BestFriend.BestFriend");
-            Assert.AreEqual(results[1][2], "BestFriend.BestFriend.BestFriend");
-            Assert.AreEqual(results[1][3], "BestFriend.BestFriend.BestFriend.BestFriend");
+            Assert.AreEqual("BestFriend", results[1][0]);
+            Assert.AreEqual("BestFriend.BestFriend", results[1][1]);
+            Assert.AreEqual("BestFriend.BestFriend.BestFriend", results[1][2]);
+            Assert.AreEqual("BestFriend.BestFriend.BestFriend.BestFriend", results[1][3]);
 
-            Assert.AreEqual(results[2][0], "CurrentOwnedVehicles");
-            Assert.AreEqual(results[2][1], "CurrentOwnedVehicles.Wheels");
+            Assert.AreEqual("CurrentOwnedVehicles", results[2][0]);
+            Assert.AreEqual("CurrentOwnedVehicles.Wheels", results[2][1]);
         }
 
         [TestMethod]
@@ -77,8 +77,8 @@ namespace NHibernate.Extensions.Tests
 
             var results = tree.DeepFirstSearch();
             //Output
-            Assert.AreEqual(results[0][0], "Identity");
-            Assert.AreEqual(results[1][0], "IdentityCard");
+            Assert.AreEqual("Identity", results[0][0]);
+            Assert.AreEqual("IdentityCard", results[1][0]);
         }
     }
 }


### PR DESCRIPTION
Firstly, this is an awesome library and I feel should be much more popular than it is (judging by the number of downloads on NuGet). It has helped me a lot with optimising queries on a rather complex relational database.

Secondly, this PR is in preparation for other PRs to come. This one just reorders the `Assert.AreEqual()` parameters in their correct order (expected value first, observed value second) to fix warnings that my static analysis tool generates. https://rules.sonarsource.com/csharp/RSPEC-3415