### PR TITLE
Support for NHibernate entity maps

### DIFF
--- a/Source/NHibernate.Extensions.Tests/BaseIncludeTest.cs
+++ b/Source/NHibernate.Extensions.Tests/BaseIncludeTest.cs
@@ -11,7 +11,7 @@ using T4FluentNH.Tests;
 
 namespace NHibernate.Extensions.Tests
 {
-    public class BaseIncludeTest
+    public abstract class BaseIncludeTest
     {
         protected void ValidateGetEntityResult(EQBPerson petra)
         {
@@ -28,6 +28,8 @@ namespace NHibernate.Extensions.Tests
             Assert.AreEqual(petra.BestFriend.BestFriend, petra.MarriedWith);
             Assert.AreEqual(1, petra.OwnedHouses.Count);
             Assert.AreEqual(2, petra.PreviouslyOwnedVehicles.Count);
+            Assert.AreEqual("Audi", petra.CurrentOwnedVehicles.First().Model);
+            Assert.AreEqual(2, petra.CurrentOwnedVehicles.First().RoadworthyTests.Count);
             foreach (var wheel in petra.CurrentOwnedVehicles.First().Wheels)
             {
                 Assert.AreEqual(235, wheel.Width);
@@ -85,24 +87,61 @@ namespace NHibernate.Extensions.Tests
             ferrari.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 320, Vehicle = ferrari });
             ferrari.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 260, Vehicle = ferrari });
             ferrari.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 260, Vehicle = ferrari });
+            ferrari.RoadworthyTests.Add(
+                new DateTime(2002, 2, 1),
+                new EQBRoadworthyTest
+                {
+                    Vehicle = ferrari,
+                    TestDate = new DateTime(2002, 2, 1),
+                    Passed = true,
+                    Comments = "I like the shade of red."
+                });
 
             var audi = new EQBVehicle { BuildYear = 2009, Model = "Audi" };
             audi.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 235, Vehicle = audi });
             audi.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 235, Vehicle = audi });
             audi.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 235, Vehicle = audi });
             audi.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 235, Vehicle = audi });
+            audi.RoadworthyTests.Add(
+                new DateTime(2009, 2, 1),
+                new EQBRoadworthyTest
+                {
+                    Vehicle = audi,
+                    TestDate = new DateTime(2009, 2, 1),
+                    Passed = false,
+                    Comments = "Brakes failing."
+                });
+            audi.RoadworthyTests.Add(
+                new DateTime(2009, 3, 1),
+                new EQBRoadworthyTest
+                {
+                    Vehicle = audi,
+                    TestDate = new DateTime(2009, 3, 1),
+                    Passed = true,
+                    Comments = "All good now."
+                });
 
             var bmw = new EQBVehicle { BuildYear = 1993, Model = "Bmw" };
             bmw.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 205, Vehicle = bmw });
             bmw.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 205, Vehicle = bmw });
             bmw.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 205, Vehicle = bmw });
             bmw.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 205, Vehicle = bmw });
+            // Deliberately not roadworth test
 
             var vw = new EQBVehicle { BuildYear = 2002, Model = "Vw" };
             vw.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 195, Vehicle = vw });
             vw.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 195, Vehicle = vw });
             vw.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 195, Vehicle = vw });
             vw.Wheels.Add(new TestEQBWheel { Diameter = 45, Width = 195, Vehicle = vw });
+            vw.RoadworthyTests.Add(
+                new DateTime(2002, 3, 1),
+                new EQBRoadworthyTest
+                {
+                    Vehicle = vw,
+                    TestDate = new DateTime(2002, 3, 1),
+                    Passed = true,
+                    Comments = "No problems."
+                });
 
             petra.PreviouslyOwnedVehicles.Add(vw);
             petra.PreviouslyOwnedVehicles.Add(bmw);

--- a/Source/NHibernate.Extensions.Tests/DeepCloneTests.cs
+++ b/Source/NHibernate.Extensions.Tests/DeepCloneTests.cs
@@ -72,7 +72,7 @@ namespace NHibernate.Extensions.Tests
 
 
         [TestMethod]
-        public void deep_clone_refereces()
+        public void deep_clone_references()
         {
             EQBPerson clone;
             EQBPerson petra;
@@ -109,6 +109,7 @@ namespace NHibernate.Extensions.Tests
             {
                 petra = session.Query<EQBPerson>()
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.PreviouslyOwnedVehicles)
                     .First(o => o.Name == "Petra");
 
@@ -122,6 +123,8 @@ namespace NHibernate.Extensions.Tests
             Assert.AreEqual(clone, clone.CurrentOwnedVehicles.First().CurrentOwner);
             Assert.AreEqual(4, clone.CurrentOwnedVehicles.First().Wheels.Count);
             Assert.AreEqual(clone.CurrentOwnedVehicles.First(), clone.CurrentOwnedVehicles.First().Wheels.First().Vehicle);
+            Assert.AreEqual(2, clone.CurrentOwnedVehicles.First().RoadworthyTests.Count);
+            Assert.AreEqual(clone.CurrentOwnedVehicles.First(), clone.CurrentOwnedVehicles.First().RoadworthyTests[new DateTime(2009, 2, 1)].Vehicle);
 
             Assert.AreEqual(2, clone.PreviouslyOwnedVehicles.Count);
             Assert.AreEqual(clone, clone.CurrentOwnedVehicles.First().CurrentOwner);
@@ -168,6 +171,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.IdentityCard)
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .First(o => o.Name == "Petra");
 
                 clone = session.DeepClone(petra, o => o
@@ -180,6 +184,8 @@ namespace NHibernate.Extensions.Tests
             Assert.IsNull(clone.CurrentOwnedVehicles.First().CurrentOwner);
             Assert.AreEqual(4, clone.CurrentOwnedVehicles.First().Wheels.Count);
             Assert.IsNull(clone.CurrentOwnedVehicles.First().Wheels.First().Vehicle);
+            Assert.AreEqual(2, clone.CurrentOwnedVehicles.First().RoadworthyTests.Count);
+            Assert.IsNull(clone.CurrentOwnedVehicles.First().RoadworthyTests.First().Value.Vehicle);
         }
 
         [TestMethod]
@@ -193,6 +199,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.IdentityCard)
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .First(o => o.Name == "Petra");
 
                 clone = session.DeepClone(petra, o => o
@@ -210,8 +217,9 @@ namespace NHibernate.Extensions.Tests
             Assert.AreEqual(4, clone.CurrentOwnedVehicles.First().Wheels.Count);
             Assert.AreEqual(0, clone.CurrentOwnedVehicles.First().Wheels.First().Id);
             Assert.AreEqual(0, clone.CurrentOwnedVehicles.First().Wheels.First().Vehicle.Id);
+            Assert.AreEqual(2, clone.CurrentOwnedVehicles.First().RoadworthyTests.Count);
+            Assert.AreEqual(0, clone.CurrentOwnedVehicles.First().RoadworthyTests.First().Value.Id);
+            Assert.AreEqual(0, clone.CurrentOwnedVehicles.First().RoadworthyTests.First().Value.Vehicle.Id);
         }
-
-
     }
 }

--- a/Source/NHibernate.Extensions.Tests/Entities/EQBRoadWorthyTest.cs
+++ b/Source/NHibernate.Extensions.Tests/Entities/EQBRoadWorthyTest.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace NHibernate.Extensions.Tests.Entities
+{
+    public partial class EQBRoadworthyTest : Entity
+    {
+        public virtual DateTime TestDate { get; set; }
+
+        public virtual bool Passed { get; set; }
+
+        public virtual string Comments { get; set; }
+
+        public virtual EQBVehicle Vehicle { get; set; }
+    }
+}

--- a/Source/NHibernate.Extensions.Tests/Entities/EQBVehicle.cs
+++ b/Source/NHibernate.Extensions.Tests/Entities/EQBVehicle.cs
@@ -1,4 +1,5 @@
-﻿using System.CodeDom;
+﻿using System;
+using System.CodeDom;
 using System.Collections.Generic;
 using FluentNHibernate.Automapping;
 using FluentNHibernate.Automapping.Alterations;
@@ -11,6 +12,7 @@ namespace NHibernate.Extensions.Tests.Entities
         {
             Wheels = new HashSet<TestEQBWheel>();
             PreviousUsers = new HashSet<EQBPerson>();
+            RoadworthyTests = new Dictionary<DateTime, EQBRoadworthyTest>();
         }
 
         public virtual string Model { get; set; }
@@ -23,7 +25,7 @@ namespace NHibernate.Extensions.Tests.Entities
 
         public virtual ISet<TestEQBWheel> Wheels { get; set; }
 
-
+        public virtual IDictionary<DateTime, EQBRoadworthyTest> RoadworthyTests { get; set; }
     }
 
     public class EQBVehicleMapping : IAutoMappingOverride<EQBVehicle>
@@ -32,6 +34,7 @@ namespace NHibernate.Extensions.Tests.Entities
         {
             mapping.HasManyToMany(o => o.PreviousUsers).Inverse();
             mapping.HasMany(o => o.Wheels).KeyColumn("VehicleId");
+            mapping.HasMany(o => o.RoadworthyTests).AsMap<DateTime>(rwt => rwt.TestDate);
         }
     }
 }

--- a/Source/NHibernate.Extensions.Tests/LinqIncludeTests.cs
+++ b/Source/NHibernate.Extensions.Tests/LinqIncludeTests.cs
@@ -30,6 +30,8 @@ namespace NHibernate.Extensions.Tests
                         .ThenFetch(o => o.BestFriend)
                     .FetchMany(o => o.CurrentOwnedVehicles)
                         .ThenFetchMany(o => o.Wheels)
+                    .FetchMany(o => o.CurrentOwnedVehicles)
+                        .ThenFetchMany(o => o.RoadworthyTests)
                     .Fetch(o => o.DrivingLicence)
                     .Fetch(o => o.IdentityCard)
                     .Fetch(o => o.MarriedWith)
@@ -56,6 +58,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles)
                     .Include(o => o.CurrentOwnedVehicles).ThenInclude(o => o.Wheels)
+                    .Include(o => o.CurrentOwnedVehicles).ThenInclude(o => o.RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.IdentityCard)
                     .Include(o => o.MarriedWith)
@@ -77,6 +80,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.IdentityCard)
                     .Include(o => o.MarriedWith)
@@ -96,6 +100,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.IdentityCard)
                     .Include(o => o.MarriedWith)
@@ -123,6 +128,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles).ThenInclude(o => o.Wheels)
+                    .Include(o => o.CurrentOwnedVehicles).ThenInclude(o => o.RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -133,7 +139,7 @@ namespace NHibernate.Extensions.Tests
                     .ToFutureValue();
                 petra = future.Value;
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -147,6 +153,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.IdentityCard)
                     .Include(o => o.MarriedWith)
@@ -172,6 +179,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.IdentityCard)
                     .Include(o => o.MarriedWith)
@@ -192,6 +200,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.IdentityCard)
                     .Include(o => o.MarriedWith)
@@ -212,6 +221,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.IdentityCard)
                     .Include(o => o.MarriedWith)
@@ -231,6 +241,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.IdentityCard)
                     .Include(o => o.MarriedWith)
@@ -253,6 +264,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.IdentityCard)
                     .Include(o => o.MarriedWith)
@@ -275,6 +287,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.IdentityCard)
                     .Include(o => o.MarriedWith)
@@ -316,6 +329,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.IdentityCard)
                     .Include(o => o.MarriedWith)
@@ -439,6 +453,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -449,7 +464,7 @@ namespace NHibernate.Extensions.Tests
                     .ToFutureValue();
                 petra = future.Value;
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -467,6 +482,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -477,7 +493,7 @@ namespace NHibernate.Extensions.Tests
                     .ToFutureValue();
                 petra = await future.GetValueAsync();
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -499,6 +515,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -508,7 +525,7 @@ namespace NHibernate.Extensions.Tests
                     .Where(o => o.Name == "Petra")
                     .SingleOrDefault();
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -526,6 +543,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -535,7 +553,7 @@ namespace NHibernate.Extensions.Tests
                     .Where(o => o.Name == "Petra")
                     .SingleOrDefaultAsync();
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -553,6 +571,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -561,7 +580,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.PreviouslyOwnedVehicles)
                     .SingleOrDefaultAsync(o => o.Name == "Petra");
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -583,6 +602,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -592,7 +612,7 @@ namespace NHibernate.Extensions.Tests
                     .Where(o => o.Name == "Petra")
                     .Single();
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -610,6 +630,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -619,7 +640,7 @@ namespace NHibernate.Extensions.Tests
                     .Where(o => o.Name == "Petra")
                     .SingleAsync();
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -637,6 +658,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -645,7 +667,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.PreviouslyOwnedVehicles)
                     .SingleAsync(o => o.Name == "Petra");
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -663,6 +685,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -671,7 +694,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.PreviouslyOwnedVehicles)
                     .Single(o => o.Name == "Petra");
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -693,6 +716,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -702,7 +726,7 @@ namespace NHibernate.Extensions.Tests
                     .Where(o => o.Name == "Petra")
                     .FirstOrDefault();
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -720,6 +744,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -729,7 +754,7 @@ namespace NHibernate.Extensions.Tests
                     .Where(o => o.Name == "Petra")
                     .FirstOrDefaultAsync();
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -747,6 +772,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -755,7 +781,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.PreviouslyOwnedVehicles)
                     .FirstOrDefaultAsync(o => o.Name == "Petra");
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -773,6 +799,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -781,7 +808,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.PreviouslyOwnedVehicles)
                     .FirstOrDefault(o => o.Name == "Petra");
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -803,6 +830,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -812,7 +840,7 @@ namespace NHibernate.Extensions.Tests
                     .Where(o => o.Name == "Petra")
                     .First();
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -830,6 +858,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -839,7 +868,7 @@ namespace NHibernate.Extensions.Tests
                     .Where(o => o.Name == "Petra")
                     .FirstAsync();
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -857,6 +886,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -865,7 +895,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.PreviouslyOwnedVehicles)
                     .FirstAsync(o => o.Name == "Petra");
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -883,6 +913,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -891,7 +922,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.PreviouslyOwnedVehicles)
                     .First(o => o.Name == "Petra");
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -913,6 +944,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -922,7 +954,7 @@ namespace NHibernate.Extensions.Tests
                     .Where(o => o.Name == "Petra")
                     .LastOrDefault();
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }
@@ -940,6 +972,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.BestFriend.IdentityCard)
                     .Include(o => o.BestFriend.BestFriend.BestFriend.BestFriend)
                     .Include(o => o.CurrentOwnedVehicles.First().Wheels)
+                    .Include(o => o.CurrentOwnedVehicles.First().RoadworthyTests)
                     .Include(o => o.DrivingLicence)
                     .Include(o => o.CreatedBy)
                     .Include(o => o.IdentityCard)
@@ -948,7 +981,7 @@ namespace NHibernate.Extensions.Tests
                     .Include(o => o.PreviouslyOwnedVehicles)
                     .LastOrDefault(o => o.Name == "Petra");
                 Assert.AreEqual(1, stats.PrepareStatementCount);
-                Assert.AreEqual("3 queries (MultiQuery)", stats.Queries[0]);
+                Assert.AreEqual("4 queries (MultiQuery)", stats.Queries[0]);
             }
             ValidateGetEntityResult(petra);
         }

--- a/Source/NHibernate.Extensions.Tests/NHibernate.Extensions.Tests.csproj
+++ b/Source/NHibernate.Extensions.Tests/NHibernate.Extensions.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="DeepCloneTests.cs" />
     <Compile Include="Entities\BatchModel.cs" />
     <Compile Include="Entities\EQBIdentity.cs" />
+    <Compile Include="Entities\EQBRoadWorthyTest.cs" />
     <Compile Include="Entities\EQBUser.cs" />
     <Compile Include="Entities\IUser.cs" />
     <Compile Include="Entities\EQBDrivingLicence.cs" />

--- a/Source/NHibernate.Extensions.Tests/QueryRelationTreeTests.cs
+++ b/Source/NHibernate.Extensions.Tests/QueryRelationTreeTests.cs
@@ -44,11 +44,13 @@ namespace NHibernate.Extensions.Tests
             Expression<Func<EQBPerson, object>> AB = person => person.BestFriend.IdentityCard;
             Expression<Func<EQBPerson, object>> AAAA = person => person.BestFriend.BestFriend.BestFriend.BestFriend;
             Expression<Func<EQBPerson, object>> CD = person => person.CurrentOwnedVehicles.First().Wheels;
+            Expression<Func<EQBPerson, object>> CE = person => person.CurrentOwnedVehicles.First().RoadworthyTests;
 
             //Input
             tree.AddNode(AB);
             tree.AddNode(AAAA);
             tree.AddNode(CD);
+            tree.AddNode(CE);
 
             var results = tree.DeepFirstSearch();
             //Output
@@ -62,6 +64,9 @@ namespace NHibernate.Extensions.Tests
 
             Assert.AreEqual("CurrentOwnedVehicles", results[2][0]);
             Assert.AreEqual("CurrentOwnedVehicles.Wheels", results[2][1]);
+
+            Assert.AreEqual("CurrentOwnedVehicles", results[3][0]);
+            Assert.AreEqual("CurrentOwnedVehicles.RoadworthyTests", results[3][1]);
         }
 
         [TestMethod]

--- a/Source/NHibernate.Extensions/Linq/IncludeQueryProvider.cs
+++ b/Source/NHibernate.Extensions/Linq/IncludeQueryProvider.cs
@@ -337,7 +337,9 @@ namespace NHibernate.Extensions.Linq
                 var relatedType = relatedProp != null ? relatedProp.PropertyType : meta.MappedClass;
                 if (propType.IsCollectionType && relatedProp != null && relatedType.IsGenericType)
                 {
-                    relatedType = relatedType.GetGenericArguments()[0];
+                    relatedType = propType.GetType().IsAssignableToGenericType(typeof(GenericMapType<,>))
+                        ? typeof(KeyValuePair<,>).MakeGenericType(relatedType.GetGenericArguments())
+                        : relatedType.GetGenericArguments()[0];
                 }
 
                 var convertToType = propType.IsCollectionType


### PR DESCRIPTION
Merge #3 first. Then I will rebase this PR.

This PR adds support for entity maps. I added tests cases using a new entity `EQBRoadworthyTest` which is mapped to a `Dictionary<DateTime, EQBRoadworthyTest>`.

The `DeepClone` implementation for `Dictionary<,>` might be a bit naive. You're welcome to suggest changes.