### PR TITLE
Enable HibernatingRhinos only if HIBERNATINGRHINOS compiler constant is present

### DIFF
--- a/Source/NHibernate.Extensions.Tests/NHConfig.cs
+++ b/Source/NHibernate.Extensions.Tests/NHConfig.cs
@@ -63,7 +63,10 @@ namespace T4FluentNH.Tests
             var schema = new SchemaExport(configuration);
             schema.Drop(false, true);
             schema.Create(false, true);
+
+#if HIBERNATINGRHINOS
             HibernatingRhinos.Profiler.Appender.NHibernate.NHibernateProfiler.Initialize();
+#endif
         }
 
         public static ISession OpenSession()

--- a/Source/NHibernate.Extensions.Tests/TestBase.cs
+++ b/Source/NHibernate.Extensions.Tests/TestBase.cs
@@ -10,7 +10,9 @@ namespace T4FluentNH.Tests
     {
         public TestBase()
         {
+#if HIBERNATINGRHINOS
             HibernatingRhinos.Profiler.Appender.NHibernate.NHibernateProfiler.Initialize();
+#endif
             Session = NHConfig.OpenSession();
         }
 


### PR DESCRIPTION
Few people have HibernatingRhinos. I don't have it.

This PR enables support for HibernatingRhinos only if the HIBERNATINGRHINOS compiler constant has been defined.