### PR TITLE
Use (localdb)\MSSQLLocalDB

### DIFF
--- a/Source/NHibernate.Extensions.Tests/App.config
+++ b/Source/NHibernate.Extensions.Tests/App.config
@@ -12,7 +12,7 @@
     </session-factory>
   </hibernate-configuration>
   <connectionStrings>
-    <add name="LocalDb" connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=Test;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|\Test.mdf" providerName="System.Data.SqlClient" />
+    <add name="LocalDb" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=Test;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|\Test.mdf" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />


### PR DESCRIPTION
Use (localdb)\MSSQLLocalDB, which isn't version specific to SQL Server Express

Just another PR to make things easier to compile the projects out of the box.